### PR TITLE
Updated highlight.js

### DIFF
--- a/src/frontend/concreteindium/package-lock.json
+++ b/src/frontend/concreteindium/package-lock.json
@@ -6042,10 +6042,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npm.taobao.org/highlight.js/download/highlight.js-10.4.0.tgz",
-      "integrity": "sha1-7zzkdeXfp6SEhCYLSeokLdq4I6A=",
-      "dev": true
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/src/frontend/concreteindium/package.json
+++ b/src/frontend/concreteindium/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "highlight.js": "^10.4.1",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^8.4.2",


### PR DESCRIPTION
Running Windows 1909.

Kolla om det är saker som går sönder ifall jag uppdaterar.  Det verkar som att Highlight.js är kopplat till frontend.

Anledningen till uppdateringen:
https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS 